### PR TITLE
test: add tests for installed extras

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,9 @@
 {
+    "version": "0.2.0",
     "configurations": [
 
         {
-            "name": "Python Debugger: Inspect",
+            "name": "Debug Inspect",
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/inspect_wandb_venv_test/bin/inspect", // Replace inspect_weave_venv with your venv
@@ -20,11 +21,13 @@
             }
         },
         {
-            "name": "Python Debugger: Run Current File",
-            "type": "debugpy",
+            "name": "Python: Current File",
+            "type": "python",
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-        }
+            "justMyCode": false,
+            "cwd": "${fileDirname}",
+        },
     ]
 }

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,0 +1,108 @@
+import pytest
+from pathlib import Path
+import subprocess
+import os
+
+@pytest.fixture(scope="function")
+def base_install_venv(tmp_path: Path) -> None:
+    subprocess.call(["uv", "venv", str(tmp_path)])
+    subprocess.call(
+        ["uv", "pip", "install", ".", "--python", tmp_path, ],
+        cwd=Path(__file__).parent.parent,
+    )
+    yield tmp_path
+
+@pytest.fixture(scope="function")
+def base_and_weave_install_venv(tmp_path: Path) -> None:
+    subprocess.call(["uv", "venv", str(tmp_path)])
+    subprocess.call(
+        ["uv", "pip", "install", ".[weave]", "--python", tmp_path, ],
+        cwd=Path(__file__).parent.parent,
+    )
+    yield tmp_path
+
+@pytest.fixture(scope="function")
+def base_and_vision_install_venv(tmp_path: Path) -> None:
+    subprocess.call(["uv", "venv", str(tmp_path)])
+    subprocess.call(
+        ["uv", "pip", "install", ".[viz]", "--python", tmp_path, ],
+        cwd=Path(__file__).parent.parent,
+    )
+    yield tmp_path
+
+@pytest.fixture(scope="function")
+def all_extras_install_venv(tmp_path: Path) -> None:
+    subprocess.call(["uv", "venv", str(tmp_path)])
+    subprocess.call(
+        ["uv", "pip", "install", ".[weave,viz]", "--python", tmp_path, ],
+        cwd=Path(__file__).parent.parent,
+    )
+    yield tmp_path
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Skipping tests in CI")
+class TestExtraInstallations:
+
+    def test_weave_hooks_dont_run_with_base_install(self, base_install_venv: Path) -> None:
+
+        # Given (base_install)
+        # When
+        proc = subprocess.Popen(
+            ["uv", "run", "--python", base_install_venv, "python", "-c", "from inspect_ai.hooks._startup import init_hooks; init_hooks()"],
+            stdout=subprocess.PIPE
+        )
+
+        stdout, _ = proc.communicate()
+        stdout = stdout.decode("utf-8")
+
+        # Then
+        assert "wandb_models_hooks" in stdout
+        assert "weave_evaluation_hooks" not in stdout
+
+    def test_weave_hooks_run_with_weave_install(self, base_and_weave_install_venv: Path) -> None:
+
+        # Given (base_and_weave_install)
+        # When
+        proc = subprocess.Popen(
+            ["uv", "run", "--python", base_and_weave_install_venv, "python", "-c", "from inspect_ai.hooks._startup import init_hooks; init_hooks()"],
+            stdout=subprocess.PIPE
+        )
+        
+        stdout, _ = proc.communicate()
+        stdout = stdout.decode("utf-8")
+
+        # Then
+        assert "wandb_models_hooks" in stdout
+        assert "weave_evaluation_hooks" in stdout
+
+    def test_all_hooks_run_with_all_extras_install(self, all_extras_install_venv: Path) -> None:
+
+        # Given (all_extras_install)
+        # When
+        proc = subprocess.Popen(
+            ["uv", "run", "--python", all_extras_install_venv, "python", "-c", "from inspect_ai.hooks._startup import init_hooks; init_hooks()"],
+            stdout=subprocess.PIPE
+        )
+
+        stdout, _ = proc.communicate()
+        stdout = stdout.decode("utf-8")
+
+        # Then
+        assert "wandb_models_hooks" in stdout
+        assert "weave_evaluation_hooks" in stdout
+
+    def test_models_hooks_run_with_viz_install(self, base_and_vision_install_venv: Path) -> None:
+
+        # Given (base_and_vision_install)
+        # When
+        proc = subprocess.Popen(
+            ["uv", "run", "--python", base_and_vision_install_venv, "python", "-c", "from inspect_ai.hooks._startup import init_hooks; init_hooks()"],
+            stdout=subprocess.PIPE
+        )
+
+        stdout, _ = proc.communicate()
+        stdout = stdout.decode("utf-8")
+
+        # Then
+        assert "wandb_models_hooks" in stdout
+        assert "weave_evaluation_hooks" not in stdout
+


### PR DESCRIPTION
## Describe your changes
I added tests for ensuring that only the relevant hooks get pulled in by inspect based on which extras the user has installed. These tests spin up a fresh venv for each run, so I have them set to skip in CI by default, but we could change that if the project gets taken over by an org with paid tier CI

## Issue ticket number and link (if applicable)

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
