### PR TITLE
add file/folder existence check before wandb save

### DIFF
--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing_extensions import override
 
 import wandb
@@ -56,7 +57,15 @@ class WandBModelHooks(Hooks):
 
         if self.settings is not None and self.settings.files:
             for file in self.settings.files:
-                 self.run.save(str(file), policy="now")  # TODO: fix wandb Symlinked warning for folder upload
+                file_path = Path(file)
+                if file_path.exists():
+                    try:
+                        self.run.save(str(file), policy="now")  # TODO: fix wandb Symlinked warning for folder upload
+                        logger.info(f"Successfully saved {file} to wandb")
+                    except Exception as e:
+                        logger.warning(f"Failed to save {file} to wandb: {e}")
+                else:
+                    logger.warning(f"File or folder '{file}' does not exist. Skipping wandb upload.")
 
         self.run.finish()
 

--- a/inspect_wandb/weave/hooks.py
+++ b/inspect_wandb/weave/hooks.py
@@ -170,7 +170,7 @@ class WeaveEvaluationHooks(Hooks):
         weave_eval_logger = self.weave_eval_loggers.get(data.eval_id)
         assert weave_eval_logger is not None
         
-        sample_id = int(data.sample.id)
+        sample_id = data.sample.id
         epoch = data.sample.epoch
         input_value = data.sample.input
         with weave.attributes({"sample_id": sample_id, "epoch": epoch}):


### PR DESCRIPTION
## Describe your changes
if the file/folder specified does not exist, give warning msg
```zsh
[08/28/2025 11:36:23] WARNING  File or folder 'READNE.md' does not exist. Skipping wandb upload.      hooks.py:68
```

## Issue ticket number and link (if applicable)
https://github.com/DanielPolatajko/inspect_wandb/issues/92#issuecomment-3218154001

## Checklist
- [ ] I have run the pre-commit checks
- [ ] I have run the unit tests and they are passing
- [ ] I have performed a self-review of my code
- [ ] I have added unit tests to cover any core logic changes
