### PR TITLE
refactor: allow all settings to be configured via script-level metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,19 +216,19 @@ The latter env var controls the Weave integration in the same manner.
 
 #### Script-Level Control (Highest Priority)
 
-For fine-grained control, you can override hook enablement settings at the script level using task metadata. This takes **highest priority** over all other configuration methods.
+For fine-grained control, you can override any settings at the script level using task metadata. This takes **highest priority** over all other configuration methods.
 With script:
 ```python
 eval(my_eval, 
   model="mockllm/model", 
   metadata={
-    "weave_enabled": True, 
-    "models_enabled": False
+    "inspect_wandb_weave_enabled": True, 
+    "inspect_wandb_models_enabled": False
     }
   )
 ```
 or with command:
-`inspect eval my_eval --metadata weave_enabled=True`
+`inspect eval my_eval --metadata inspect_wandb_weave_enabled=True`
 
 
 

--- a/inspect_wandb/config/settings.py
+++ b/inspect_wandb/config/settings.py
@@ -38,15 +38,15 @@ class ModelsSettings(BaseSettings):
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         """
         Customise the priority of settings sources to prioritise as follows:
-        1. Environment variables (highest priority)
-        2. Wandb settings file (for entity/project)
-        3. Initial settings (programmatic overrides)
+        1. Initial settings (can be set via eval metadata fields)
+        2. Environment variables (highest priority)
+        3. Wandb settings file (for entity/project)
         4. Pyproject.toml (lowest priority)
         """
         return (
+            init_settings,
             env_settings, 
-            WandBSettingsSource(settings_cls),
-            init_settings, 
+            WandBSettingsSource(settings_cls), 
             PyprojectTomlConfigSettingsSource(settings_cls)
         )
 
@@ -82,15 +82,15 @@ class WeaveSettings(BaseSettings):
     ) -> tuple[PydanticBaseSettingsSource, ...]:
         """
         Customise the priority of settings sources to prioritise as follows:
-        1. Environment variables (highest priority)
-        2. Wandb settings file (for entity/project)
-        3. Initial settings (programmatic overrides)
+        1. Initial settings (can be set via eval metadata fields)
+        2. Environment variables (highest priority)
+        3. Wandb settings file (for entity/project)
         4. Pyproject.toml (lowest priority)
         """
         return (
+            init_settings,
             env_settings, 
             WandBSettingsSource(settings_cls),
-            init_settings, 
             PyprojectTomlConfigSettingsSource(settings_cls)
         )
 

--- a/inspect_wandb/config/settings_loader.py
+++ b/inspect_wandb/config/settings_loader.py
@@ -11,9 +11,9 @@ class SettingsLoader:
     def load_inspect_wandb_settings(cls, settings: dict[str, Any] | None = None) -> InspectWandBSettings:
         """
         Load settings with this priority:
-        1. Environment variables (both WANDB_* vars defined by W&B, and INSPECT_WANDB_* vars defined by this package)
-        2. Wandb settings file (for entity/project - handled by WandBSettingsSource)
-        3. Initial settings (programmatic overrides provided to the settings argument)
+        1. Initial settings (programmatic overrides provided to the settings argument)
+        2. Environment variables (both WANDB_* vars defined by W&B, and INSPECT_WANDB_* vars defined by this package)
+        3. Wandb settings file (for entity/project - handled by WandBSettingsSource)
         4. Pyproject.toml customizations
         5. Defaults if no other source provides values
         


### PR DESCRIPTION
## Describe your changes

This PR removes the custom handling for enabled settings being set in the eval or eval-set metadata, moves this handling to the generic settings loader, and makes these overrides priority. This means all settings can now be configured in this way.

## Issue ticket number and link (if applicable)

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
