### PR TITLE
feat(models): add eval metadata to wandb config by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "ruff.nativeServer": "on"
 }

--- a/inspect_wandb/config/settings.py
+++ b/inspect_wandb/config/settings.py
@@ -24,6 +24,7 @@ class ModelsSettings(BaseSettings):
     config: dict[str, Any] | None = Field(default=None, description="Configuration to pass directly to wandb.config for the Models integration")
     files: list[str] | None = Field(default=None, description="Files to upload to the models run. Paths should be relative to the wandb directory.")
     viz: bool = Field(default=False, description="Whether to enable the inspect_viz extra")
+    add_metadata_to_config: bool = Field(default=True, description="Whether to add eval metadata to wandb.config")
 
     tags: list[str] | None = Field(default=None, description="Tags to add to the models run")
 

--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -157,7 +157,7 @@ class WandBModelHooks(Hooks):
         """
         if data.spec.metadata is None:
             return None
-        return {k:v for k,v in data.spec.metadata.items() if k.startswith("inspect_wandb_models_")}
+        return { k[len("inspect_wandb_models_"):]: v for k,v in data.spec.metadata.items() if k.startswith("inspect_wandb_models_")}
 
     def _load_settings(self, overrides: dict[str, Any] | None = None) -> None:
         if self.settings is None or overrides is not None:

--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -85,6 +85,8 @@ class WandBModelHooks(Hooks):
         if not self._wandb_initialized:
             self.run = wandb.init(id=data.run_id, entity=self.settings.entity, project=self.settings.project) 
 
+            if self.settings.add_metadata_to_config and data.spec.metadata is not None:
+                self.run.config.update({k: v for k,v in data.spec.metadata.items() if k != "inspect_wandb_models_config"})
             if self.settings.config:
                 self.run.config.update(self.settings.config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ inspect_wandb = "inspect_wandb._registry"
 exclude = [
     "inspect_wandb/_registry.py"
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_models/test_hooks.py
+++ b/tests/test_models/test_hooks.py
@@ -95,6 +95,51 @@ class TestWandBModelHooks:
             assert hooks.run.tags == ("inspect_task:test_task", "inspect_model:mockllm/model", "inspect_dataset:test-dataset")
 
     @pytest.mark.asyncio
+    async def test_wandb_config_updated_with_eval_metadata(self, mock_wandb_run: Run, create_task_start: Callable[dict | None, TaskStart]) -> None:
+        """
+        Test that the on_task_start method initializes the WandB run with config.
+        """
+        hooks = WandBModelHooks()
+        mock_init = MagicMock(return_value=mock_wandb_run)
+        task_start = create_task_start()
+        task_start.spec.metadata = {"test": "test"}
+        hooks.settings = ModelsSettings(
+            enabled=True, 
+            entity="test-entity", 
+            project="test-project"
+        )
+        with patch('inspect_wandb.models.hooks.wandb.init', mock_init):
+            await hooks.on_task_start(task_start)
+            mock_init.assert_called_once_with(id="test_run_id", entity="test-entity", project="test-project")
+            assert hooks._wandb_initialized is True
+            assert hooks.run is mock_wandb_run
+            hooks.run.config.update.assert_called_once_with({"test": "test"})
+
+    @pytest.mark.asyncio
+    async def test_wandb_config_not_updated_with_eval_metadata_if_add_metadata_to_config_is_false(self, mock_wandb_run: Run, create_task_start: Callable[dict | None, TaskStart]) -> None:
+        """
+        Test that the on_task_start method initializes the WandB run with config.
+        """
+        hooks = WandBModelHooks()
+        mock_init = MagicMock(return_value=mock_wandb_run)
+        task_start = create_task_start()
+        task_start.spec.metadata = {"test": "test"}
+        hooks.settings = ModelsSettings(
+            enabled=True, 
+            entity="test-entity", 
+            project="test-project",
+            add_metadata_to_config=False
+        )
+        with patch('inspect_wandb.models.hooks.wandb.init', mock_init):
+            await hooks.on_task_start(task_start)
+            mock_init.assert_called_once_with(id="test_run_id", entity="test-entity", project="test-project")
+            assert hooks._wandb_initialized is True
+            assert hooks.run is mock_wandb_run
+            hooks.run.config.update.assert_not_called()
+            hooks.run.define_metric.assert_called_once_with(step_metric=Metric.SAMPLES, name=Metric.ACCURACY)
+            assert hooks.run.tags == ("inspect_task:test_task", "inspect_model:mockllm/model", "inspect_dataset:test-dataset")
+
+    @pytest.mark.asyncio
     async def test_wandb_tags_updated_on_task_start_if_settings_tags_are_set(self, mock_wandb_run: Run, create_task_start: Callable[dict | None, TaskStart]) -> None:
         """
         Test that the on_task_start method adds settings tags to the run tags.

--- a/tests/test_models/test_hooks.py
+++ b/tests/test_models/test_hooks.py
@@ -128,16 +128,16 @@ class TestWandBModelHooks:
             enabled=True, 
             entity="test-entity", 
             project="test-project",
-            add_metadata_to_config=False
+            add_metadata_to_config=False,
+            config=None
         )
+        hooks._hooks_enabled = True
         with patch('inspect_wandb.models.hooks.wandb.init', mock_init):
             await hooks.on_task_start(task_start)
             mock_init.assert_called_once_with(id="test_run_id", entity="test-entity", project="test-project")
             assert hooks._wandb_initialized is True
             assert hooks.run is mock_wandb_run
             hooks.run.config.update.assert_not_called()
-            hooks.run.define_metric.assert_called_once_with(step_metric=Metric.SAMPLES, name=Metric.ACCURACY)
-            assert hooks.run.tags == ("inspect_task:test_task", "inspect_model:mockllm/model", "inspect_dataset:test-dataset")
 
     @pytest.mark.asyncio
     async def test_wandb_tags_updated_on_task_start_if_settings_tags_are_set(self, mock_wandb_run: Run, create_task_start: Callable[dict | None, TaskStart]) -> None:


### PR DESCRIPTION
## Describe your changes

Add the full metadata (except any additional config) to the config passed to wandb

## Issue ticket number and link (if applicable)

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
