### PR TITLE
fix: track models error states 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - This CHANGELOG!
 - Contributor guidelines
 
+### Fixed
+- Simplified log summary of outputs metric on Weave
+- Better handling of error states for Models runs
+
 ## [v0.1.0](https://pypi.org/project/inspect-wandb/0.1.0/) (07 September 2025)
 
 ### Added

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,6 +7,7 @@ installation.md
 tutorial.md
 configuration.md
 contributing.md
+faq.md
 ```
 
 **Inspect WandB** is a Python library for integrating the [Inspect AI framework](https://inspect.aisi.org.uk/) with Weights and Biases [Models](https://wandb.ai/site/models/) API and [Weave](https://wandb.ai/site/weave/).

--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -29,6 +29,7 @@ class WandBModelHooks(Hooks):
     _wandb_initialized: bool = False
     _is_eval_set: bool = False
     _hooks_enabled: bool | None = None
+    _active_runs: dict[str, dict[str, bool | BaseException | None]] = {}
 
     def __init__(self):
         if INSTALLED_EXTRAS["viz"]:
@@ -57,6 +58,10 @@ class WandBModelHooks(Hooks):
         if not self._wandb_initialized:
             return
 
+        self._active_runs[data.run_id]["running"] = False
+        if data.exception is not None:
+            self._active_runs[data.run_id]["exception"] = data.exception
+
         self._log_summary(data)
 
         if self.settings is not None and self.settings.viz and self.viz_writer is not None:
@@ -74,26 +79,21 @@ class WandBModelHooks(Hooks):
                 else:
                     logger.warning(f"File or folder '{file}' does not exist. Skipping wandb upload.")
 
-        self._wandb_initialized = False
-
-        match data.exception:
-            case KeyboardInterrupt():
-                logger.error("Inspect exited due to KeyboardInterrupt")
-                self.run.finish(exit_code=1)
-                return
-            case Exception():
-                logger.exception(data.exception)
-                self.run.finish(exit_code=2)
-                return
-            case SystemExit() as sysexit:
-                logger.error(f"SystemExit running eval set: {sysexit}")
-                self.run.finish(exit_code=3)
-                return
-            
-        if not(all(log.status == "success" for log in data.logs)):
+        if data.exception is not None and isinstance(data.exception, KeyboardInterrupt):
+            self._wandb_initialized = False
+            logger.error("Inspect exited due to KeyboardInterrupt")
+            self.run.finish(exit_code=1)
+        elif data.exception is not None and isinstance(data.exception, SystemExit):
+            self._wandb_initialized = False
+            logger.error(f"SystemExit running eval set: {data.exception}")
+            self.run.finish(exit_code=3)
+        elif data.exception is not None and (last_run:= all([not run["running"] for run in self._active_runs.values()])):
+            logger.error("Inspect exited due to exception")
+            self.run.finish(exit_code=2)
+        elif not(all(log.status == "success" for log in data.logs)) and last_run:
             logger.warning("One or more tasks failed, may retry if eval-set")
             self.run.finish(exit_code=4)
-        else:
+        elif last_run:
             self.run.finish()
 
     @override
@@ -121,11 +121,14 @@ class WandBModelHooks(Hooks):
             wandb_run_id = format_wandb_id_string(self.eval_set_log_dir)
         else:
             wandb_run_id = data.eval_id
+
+        self._active_runs[wandb_run_id] = {
+            "running": True,
+            "exception": None,
+        }
         
         # Lazy initialization: only init WandB when first task starts
-        print(self._wandb_initialized)
         if not self._wandb_initialized:
-            print("Initializing WandB...")
             self.run = wandb.init(
                 id=wandb_run_id, 
                 name=f"Inspect eval-set: {self.eval_set_log_dir}" if self._is_eval_set else None,

--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -87,7 +87,7 @@ class WandBModelHooks(Hooks):
             self._wandb_initialized = False
             logger.error(f"SystemExit running eval set: {data.exception}")
             self.run.finish(exit_code=3)
-        elif data.exception is not None and (last_run:= all([not run["running"] for run in self._active_runs.values()])):
+        elif (last_run:= all([not run["running"] for run in self._active_runs.values()])) and data.exception is not None:
             logger.error("Inspect exited due to exception")
             self.run.finish(exit_code=2)
         elif not(all(log.status == "success" for log in data.logs)) and last_run:
@@ -122,7 +122,7 @@ class WandBModelHooks(Hooks):
         else:
             wandb_run_id = data.eval_id
 
-        self._active_runs[wandb_run_id] = {
+        self._active_runs[data.run_id] = {
             "running": True,
             "exception": None,
         }

--- a/tests/test_models/test_hooks.py
+++ b/tests/test_models/test_hooks.py
@@ -238,6 +238,7 @@ class TestWandBModelHooks:
         hooks._correct_samples = 5
         hooks._hooks_enabled = True
         hooks._wandb_initialized = True
+        hooks._active_runs = {"test-run": {"running": True, "exception": None}}
 
         # When
         await hooks.on_run_end(
@@ -273,6 +274,7 @@ class TestWandBModelHooks:
         hooks._correct_samples = 5
         hooks._hooks_enabled = True
         hooks._wandb_initialized = True
+        hooks._active_runs = {"test-run": {"running": True, "exception": None}}
 
         # When - mock Path.exists() to return True
         with patch('inspect_wandb.models.hooks.Path.exists', return_value=True):
@@ -302,6 +304,7 @@ class TestWandBModelHooks:
         )
         hooks._hooks_enabled = True
         hooks._wandb_initialized = True
+        hooks._active_runs = {"test-run": {"running": True, "exception": None}}
 
         # When - mock Path.exists() to return False and capture logger
         with patch('inspect_wandb.models.hooks.Path.exists', return_value=False), \
@@ -334,6 +337,7 @@ class TestWandBModelHooks:
         )
         hooks._hooks_enabled = True
         hooks._wandb_initialized = True
+        hooks._active_runs = {"test-run": {"running": True, "exception": None}}
 
         # When - mock Path.exists() to return True and capture logger
         with patch('inspect_wandb.models.hooks.Path.exists', return_value=True), \
@@ -365,6 +369,7 @@ class TestWandBModelHooks:
         )
         hooks._hooks_enabled = True
         hooks._wandb_initialized = True
+        hooks._active_runs = {"test-run": {"running": True, "exception": None}}
 
         # When - mock Path constructor to control exists() method
         def mock_path_constructor(file_str):
@@ -403,6 +408,7 @@ class TestWandBModelHooks:
         hooks._hooks_enabled = True
         hooks._wandb_initialized = True
         hooks.run.url = "test_url"
+        hooks._active_runs = {"test-run": {"running": True, "exception": None}}
 
         # When
         await hooks.on_task_end(


### PR DESCRIPTION
## Describe your changes

Closely track model runs state to prevent a situation where one run finishes and ends the wandb run before all the runs have finished

## Issue ticket number and link (if applicable)

## Checklist
- [ ] I have run the pre-commit checks
- [ ] I have run the unit tests and they are passing
- [ ] I have performed a self-review of my code
- [ ] I have added unit tests to cover any core logic changes
- [ ] I have updated the CHANGELOG.md with my changes, if necessary
