### PR TITLE
fix: use eval set ID rather than log dir to manage runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Integration between [Inspect](https://inspect.aisi.org.uk/) and [Weights & Biase
 
 ![Docs Build](https://app.readthedocs.org/projects/inspect-wandb/badge/?version=latest)
 [![Package Build](https://github.com/DanielPolatajko/inspect_wandb/actions/workflows/test-build.yml/badge.svg)](https://github.com/DanielPolatajko/inspect_wandb/actions/workflows/test-build.yml)
+[![Publish to PyPI](https://github.com/DanielPolatajko/inspect_wandb/actions/workflows/publish-to-pypi.yml/badge.svg)](https://github.com/DanielPolatajko/inspect_wandb/actions/workflows/publish-to-pypi.yml)
 
 ## Demo Video
 

--- a/inspect_wandb/models/hooks.py
+++ b/inspect_wandb/models/hooks.py
@@ -9,7 +9,6 @@ from inspect_ai.log import EvalSample
 from inspect_ai.scorer import CORRECT
 from inspect_wandb.config.settings_loader import SettingsLoader
 from inspect_wandb.config.settings import ModelsSettings
-from inspect_wandb.shared.utils import format_wandb_id_string
 from inspect_wandb.config.extras_manager import INSTALLED_EXTRAS
 if INSTALLED_EXTRAS["viz"]:
     from inspect_wandb.viz.inspect_viz_writer import InspectVizWriter
@@ -118,7 +117,7 @@ class WandBModelHooks(Hooks):
             return
         
         if self._is_eval_set:
-            wandb_run_id = format_wandb_id_string(self.eval_set_log_dir)
+            wandb_run_id = data.eval_set_id
         else:
             wandb_run_id = data.eval_id
 

--- a/tests/test_models/test_e2e_retry_scenarios.py
+++ b/tests/test_models/test_e2e_retry_scenarios.py
@@ -9,7 +9,6 @@ from inspect_ai.solver import Solver, TaskState, Generate, solver, generate
 from inspect_wandb.config.settings import ModelsSettings, WeaveSettings
 from inspect_ai._util.registry import registry_find
 import inspect_ai.hooks._startup as hooks_startup_module
-from inspect_wandb.shared.utils import format_wandb_id_string
 from uuid import uuid4
 from typing import Sequence
 
@@ -105,8 +104,6 @@ class TestWandBModelHooksE2ERetryScenarios:
             eval_set_ids = [call[1]['id'] for call in mock_wandb_init.call_args_list]
 
             assert len(set(eval_set_ids)) == 1
-            
-            assert eval_set_ids[0] == format_wandb_id_string(str(tmp_path / uid))
             
             assert len(logs) == 2
 

--- a/tests/test_models/test_hooks.py
+++ b/tests/test_models/test_hooks.py
@@ -112,7 +112,7 @@ class TestWandBModelHooks:
         with patch('inspect_wandb.models.hooks.wandb.init', mock_init):
             await hooks.on_task_start(task_start)
 
-            mock_init.assert_called_once_with(id="test_eval_set_log_dir", name="Inspect eval-set: test_eval_set_log_dir", entity="test-entity", project="test-project", resume="allow")
+            mock_init.assert_called_once_with(id="test_eval_set_id", name="Inspect eval-set: test_eval_set_log_dir", entity="test-entity", project="test-project", resume="allow")
             assert hooks._wandb_initialized is True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Using the log dir directly can be misleading e.g. people use default log dirs across multiple projects. Using the eval-set-id is more robust, and we can keep the name human readable with the log dir anyway

## Issue ticket number and link (if applicable)

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
- [x] I have updated the CHANGELOG.md with my changes, if necessary
