### PR TITLE
feat(weave): add eval set log dir to weave metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Added
+- Add eval-set log dir to Weave Evaluation metadata
+
 ## [v0.1.7](https://pypi.org/project/inspect-wandb/0.1.7/) (06 October 2025)
 
 


### PR DESCRIPTION
## Describe your changes

Adding the eval-set log dir to the weave metadata because its quite useful

## Issue ticket number and link (if applicable)

## Checklist
- [x] I have run the pre-commit checks
- [x] I have run the unit tests and they are passing
- [x] I have performed a self-review of my code
- [x] I have added unit tests to cover any core logic changes
- [x] I have updated the CHANGELOG.md with my changes, if necessary
